### PR TITLE
Kareem/feature/booking match

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -2,6 +2,7 @@
 <project version="4">
   <component name="CompilerConfiguration">
     <annotationProcessing>
+      <profile default="true" name="Default" enabled="true" />
       <profile name="Annotation profile for football-places-booking-system" enabled="true">
         <sourceOutputDir name="target/generated-sources/annotations" />
         <sourceTestOutputDir name="target/generated-test-sources/test-annotations" />

--- a/football-places-booking-system/pom.xml
+++ b/football-places-booking-system/pom.xml
@@ -39,27 +39,27 @@
 			<artifactId>spring-boot-starter-mail</artifactId>
 		</dependency>
 
-		<!-- Security Dependencies -->
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-security</artifactId>
-		</dependency>
+<!--		&lt;!&ndash; Security Dependencies &ndash;&gt;-->
+<!--		<dependency>-->
+<!--			<groupId>org.springframework.boot</groupId>-->
+<!--			<artifactId>spring-boot-starter-security</artifactId>-->
+<!--		</dependency>-->
 
-		<dependency>
-			<groupId>io.jsonwebtoken</groupId>
-			<artifactId>jjwt-api</artifactId>
-			<version>0.11.5</version>
-		</dependency>
-		<dependency>
-			<groupId>io.jsonwebtoken</groupId>
-			<artifactId>jjwt-impl</artifactId>
-			<version>0.11.5</version>
-		</dependency>
-		<dependency>
-			<groupId>io.jsonwebtoken</groupId>
-			<artifactId>jjwt-jackson</artifactId>
-			<version>0.11.5</version>
-		</dependency>
+<!--		<dependency>-->
+<!--			<groupId>io.jsonwebtoken</groupId>-->
+<!--			<artifactId>jjwt-api</artifactId>-->
+<!--			<version>0.11.5</version>-->
+<!--		</dependency>-->
+<!--		<dependency>-->
+<!--			<groupId>io.jsonwebtoken</groupId>-->
+<!--			<artifactId>jjwt-impl</artifactId>-->
+<!--			<version>0.11.5</version>-->
+<!--		</dependency>-->
+<!--		<dependency>-->
+<!--			<groupId>io.jsonwebtoken</groupId>-->
+<!--			<artifactId>jjwt-jackson</artifactId>-->
+<!--			<version>0.11.5</version>-->
+<!--		</dependency>-->
 
 
 		<dependency>

--- a/football-places-booking-system/src/main/java/hypercell/final_project/football_places_booking_system/controller/BookingMatchController.java
+++ b/football-places-booking-system/src/main/java/hypercell/final_project/football_places_booking_system/controller/BookingMatchController.java
@@ -11,6 +11,8 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+// Handles HTTP requests related to booking football matches.
+// Delegates business logic to BookingMatchService.
 @RestController
 @RequestMapping("/api/booking-matches")
 @RequiredArgsConstructor
@@ -18,31 +20,48 @@ public class BookingMatchController {
 
     private final BookingMatchService bookingMatchService;
 
+    // Creates a new booking match using data from the client (DTO).
     @PostMapping
     public ResponseEntity<BookingMatch> create(@RequestBody BookingMatchDTO dto) {
         BookingMatch created = bookingMatchService.createBookingMatch(dto);
         return new ResponseEntity<>(created, HttpStatus.CREATED);
     }
 
+    // Cancels a booking match by its ID.
     @PutMapping("/{id}/cancel")
     public ResponseEntity<BookingMatch> cancel(@PathVariable Long id) {
         BookingMatch cancelled = bookingMatchService.cancelBooking(id);
         return ResponseEntity.ok(cancelled);
     }
 
+    // Retrieves a booking match by its ID.
     @GetMapping("/{id}")
     public ResponseEntity<BookingMatch> getById(@PathVariable Long id) {
         BookingMatch match = bookingMatchService.getById(id);
         return ResponseEntity.ok(match);
     }
 
+    // Lists all booking matches for a specific user.
     @GetMapping("/user/{userId}")
     public ResponseEntity<List<BookingMatch>> getByUser(@PathVariable Long userId) {
         return ResponseEntity.ok(bookingMatchService.getByUser(userId));
     }
 
+    // Lists all booking matches for a specific place.
+    @GetMapping("/place/{placeId}")
+    public ResponseEntity<List<BookingMatch>> getByPlace(@PathVariable Long placeId) {
+        return ResponseEntity.ok(bookingMatchService.getByPlace(placeId));
+    }
+
+    // Lists all booking matches for a specific team.
     @GetMapping("/team/{teamId}")
     public ResponseEntity<List<BookingMatch>> getByTeam(@PathVariable Long teamId) {
         return ResponseEntity.ok(bookingMatchService.getByTeam(teamId));
+    }
+
+    // Lists all booking matches in the system.
+    @GetMapping("/all")
+    public ResponseEntity<List<BookingMatch>> getAll() {
+        return ResponseEntity.ok(bookingMatchService.getAll());
     }
 }

--- a/football-places-booking-system/src/main/java/hypercell/final_project/football_places_booking_system/controller/BookingMatchController.java
+++ b/football-places-booking-system/src/main/java/hypercell/final_project/football_places_booking_system/controller/BookingMatchController.java
@@ -1,0 +1,48 @@
+package hypercell.final_project.football_places_booking_system.controller;
+
+import hypercell.final_project.football_places_booking_system.model.db.BookingMatch;
+import hypercell.final_project.football_places_booking_system.model.dto.BookingMatchDTO;
+import hypercell.final_project.football_places_booking_system.service.BookingMatchService;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/booking-matches")
+@RequiredArgsConstructor
+public class BookingMatchController {
+
+    private final BookingMatchService bookingMatchService;
+
+    @PostMapping
+    public ResponseEntity<BookingMatch> create(@RequestBody BookingMatchDTO dto) {
+        BookingMatch created = bookingMatchService.createBookingMatch(dto);
+        return new ResponseEntity<>(created, HttpStatus.CREATED);
+    }
+
+    @PutMapping("/{id}/cancel")
+    public ResponseEntity<BookingMatch> cancel(@PathVariable Long id) {
+        BookingMatch cancelled = bookingMatchService.cancelBooking(id);
+        return ResponseEntity.ok(cancelled);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<BookingMatch> getById(@PathVariable Long id) {
+        BookingMatch match = bookingMatchService.getById(id);
+        return ResponseEntity.ok(match);
+    }
+
+    @GetMapping("/user/{userId}")
+    public ResponseEntity<List<BookingMatch>> getByUser(@PathVariable Long userId) {
+        return ResponseEntity.ok(bookingMatchService.getByUser(userId));
+    }
+
+    @GetMapping("/team/{teamId}")
+    public ResponseEntity<List<BookingMatch>> getByTeam(@PathVariable Long teamId) {
+        return ResponseEntity.ok(bookingMatchService.getByTeam(teamId));
+    }
+}

--- a/football-places-booking-system/src/main/java/hypercell/final_project/football_places_booking_system/model/db/BookingMatch.java
+++ b/football-places-booking-system/src/main/java/hypercell/final_project/football_places_booking_system/model/db/BookingMatch.java
@@ -1,23 +1,16 @@
 package hypercell.final_project.football_places_booking_system.model.db;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import hypercell.final_project.football_places_booking_system.model.enums.MatchStatus;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import jakarta.persistence.*;
+import lombok.*;
 
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
@@ -43,5 +36,8 @@ public class BookingMatch extends BaseEntity {
     @ManyToOne
     @JoinColumn(name = "team_id")
     private Team team;
+
+    @OneToMany(mappedBy = "bookingMatch", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MatchParticipant> participants = new ArrayList<>();
 }
 

--- a/football-places-booking-system/src/main/java/hypercell/final_project/football_places_booking_system/model/db/BookingMatch.java
+++ b/football-places-booking-system/src/main/java/hypercell/final_project/football_places_booking_system/model/db/BookingMatch.java
@@ -8,6 +8,10 @@ import hypercell.final_project.football_places_booking_system.model.enums.MatchS
 import jakarta.persistence.*;
 import lombok.*;
 
+/**
+ * Entity representing a football match booking.
+ * Links to Place, User, Team, and has a list of participants.
+ */
 @Entity
 @Getter
 @Setter
@@ -19,25 +23,30 @@ public class BookingMatch extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    // Start and end times for the match booking.
     private LocalDateTime startTime;
     private LocalDateTime endTime;
 
+    // Status of the match (e.g., PENDING, CANCELLED).
     @Enumerated(EnumType.STRING)
     private MatchStatus status;
 
+    // The place where the match is booked.
     @ManyToOne
     @JoinColumn(name = "place_id")
     private Place place;
 
+    // The user who made the booking.
     @ManyToOne
     @JoinColumn(name = "user_id")
     private User user;
 
+    // The team associated with the booking.
     @ManyToOne
     @JoinColumn(name = "team_id")
     private Team team;
 
+    // List of participants in the match.
     @OneToMany(mappedBy = "bookingMatch", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MatchParticipant> participants = new ArrayList<>();
 }
-

--- a/football-places-booking-system/src/main/java/hypercell/final_project/football_places_booking_system/model/dto/BookingMatchDTO.java
+++ b/football-places-booking-system/src/main/java/hypercell/final_project/football_places_booking_system/model/dto/BookingMatchDTO.java
@@ -1,0 +1,12 @@
+package hypercell.final_project.football_places_booking_system.model.dto;
+
+import java.time.LocalDateTime;
+
+public record BookingMatchDTO(
+        Long placeId,
+        Long userId,
+        Long teamId,
+        LocalDateTime startTime,
+        LocalDateTime endTime
+) {}
+

--- a/football-places-booking-system/src/main/java/hypercell/final_project/football_places_booking_system/model/dto/BookingMatchDTO.java
+++ b/football-places-booking-system/src/main/java/hypercell/final_project/football_places_booking_system/model/dto/BookingMatchDTO.java
@@ -2,6 +2,7 @@ package hypercell.final_project.football_places_booking_system.model.dto;
 
 import java.time.LocalDateTime;
 
+// DTO for creating a booking match. Used to transfer booking data from client to server.
 public record BookingMatchDTO(
         Long placeId,
         Long userId,
@@ -9,4 +10,3 @@ public record BookingMatchDTO(
         LocalDateTime startTime,
         LocalDateTime endTime
 ) {}
-

--- a/football-places-booking-system/src/main/java/hypercell/final_project/football_places_booking_system/repository/BookingMatchRepository.java
+++ b/football-places-booking-system/src/main/java/hypercell/final_project/football_places_booking_system/repository/BookingMatchRepository.java
@@ -1,0 +1,15 @@
+package hypercell.final_project.football_places_booking_system.repository;
+
+import hypercell.final_project.football_places_booking_system.model.db.BookingMatch;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface BookingMatchRepository extends JpaRepository<BookingMatch, Long> {
+    List<BookingMatch> findByTeamId(Long teamId);
+    List<BookingMatch> findByUserId(Long userId);
+    List<BookingMatch> findByPlaceId(Long placeId);
+}
+

--- a/football-places-booking-system/src/main/java/hypercell/final_project/football_places_booking_system/service/BookingMatchService.java
+++ b/football-places-booking-system/src/main/java/hypercell/final_project/football_places_booking_system/service/BookingMatchService.java
@@ -1,0 +1,100 @@
+package hypercell.final_project.football_places_booking_system.service;
+
+import hypercell.final_project.football_places_booking_system.model.db.BookingMatch;
+import hypercell.final_project.football_places_booking_system.model.db.Place;
+import hypercell.final_project.football_places_booking_system.model.db.Team;
+import hypercell.final_project.football_places_booking_system.model.db.User;
+import hypercell.final_project.football_places_booking_system.model.dto.BookingMatchDTO;
+import hypercell.final_project.football_places_booking_system.model.enums.MatchStatus;
+
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class BookingMatchService {
+
+    // FAKE DATA (replace with @Autowired repositories later)
+    private final List<BookingMatch> dummyMatches = new ArrayList<>();
+    private List<User> dummyUsers = new ArrayList<>();
+    private List<Place> dummyPlaces = new ArrayList<>();
+    private List<Team> dummyTeams = new ArrayList<>();
+
+    public BookingMatch createBookingMatch(BookingMatchDTO dto) {
+        // Step 1: Check for time slot overlap
+        boolean isAvailable = dummyMatches.stream()
+                .filter(m -> m.getPlace().getId().equals(dto.placeId()))
+                .noneMatch(existing ->
+                        existing.getStartTime().isBefore(dto.endTime()) &&
+                                existing.getEndTime().isAfter(dto.startTime())
+                );
+
+        if (!isAvailable) {
+            throw new IllegalStateException("Time slot is already booked for this place.");
+        }
+
+        // Step 2: Fake fetches entities
+        Place place = dummyPlaces.stream()
+                .filter(p -> p.getId().equals(dto.placeId()))
+                .findFirst()
+                .orElseThrow(() -> new EntityNotFoundException("Place not found"));
+
+        User user = dummyUsers.stream()
+                .filter(u -> u.getId().equals(dto.userId()))
+                .findFirst()
+                .orElseThrow(() -> new EntityNotFoundException("User not found"));
+
+        Team team = dummyTeams.stream()
+                .filter(t -> t.getId().equals(dto.teamId()))
+                .findFirst()
+                .orElseThrow(() -> new EntityNotFoundException("Team not found"));
+
+        // Step 3: Create and store match
+        BookingMatch match = BookingMatch.builder()
+                .id((long) (dummyMatches.size() + 1)) // Simulate auto ID
+                .place(place)
+                .user(user)
+                .team(team)
+                .startTime(dto.startTime())
+                .endTime(dto.endTime())
+                .status(MatchStatus.PENDING)
+                .build();
+
+        dummyMatches.add(match);
+        return match;
+    }
+
+    public BookingMatch cancelBooking(Long matchId) {
+        BookingMatch match = getById(matchId);
+        match.setStatus(MatchStatus.CANCELLED);
+        return match;
+    }
+
+    public BookingMatch getById(Long id) {
+        return dummyMatches.stream()
+                .filter(m -> m.getId().equals(id))
+                .findFirst()
+                .orElseThrow(() -> new EntityNotFoundException("Match not found"));
+    }
+
+    public List<BookingMatch> getByUser(Long userId) {
+        return dummyMatches.stream()
+                .filter(m -> m.getUser().getId().equals(userId))
+                .toList();
+    }
+
+    public List<BookingMatch> getByTeam(Long teamId) {
+        return dummyMatches.stream()
+                .filter(m -> m.getTeam().getId().equals(teamId))
+                .toList();
+    }
+
+    // Optional: Method to preload fake data for testing
+    public void seedData(List<User> users, List<Place> places, List<Team> teams) {
+        this.dummyUsers = users;
+        this.dummyPlaces = places;
+        this.dummyTeams = teams;
+    }
+}

--- a/football-places-booking-system/src/main/java/hypercell/final_project/football_places_booking_system/service/BookingMatchService.java
+++ b/football-places-booking-system/src/main/java/hypercell/final_project/football_places_booking_system/service/BookingMatchService.java
@@ -7,23 +7,32 @@ import hypercell.final_project.football_places_booking_system.model.db.User;
 import hypercell.final_project.football_places_booking_system.model.dto.BookingMatchDTO;
 import hypercell.final_project.football_places_booking_system.model.enums.MatchStatus;
 
+import hypercell.final_project.football_places_booking_system.repository.BookingMatchRepository;
 import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
+// Service layer for booking match logic. Uses in-memory lists for demo/testing.
+@Slf4j
 @Service
+@RequiredArgsConstructor
 public class BookingMatchService {
 
-    // FAKE DATA (replace with @Autowired repositories later)
+    // In-memory lists for demo purposes. Replace repositories for production.
     private final List<BookingMatch> dummyMatches = new ArrayList<>();
     private List<User> dummyUsers = new ArrayList<>();
     private List<Place> dummyPlaces = new ArrayList<>();
     private List<Team> dummyTeams = new ArrayList<>();
+    private final BookingMatchRepository bookingMatchRepository;
 
+    // Creates a booking match after checking for time slot conflicts.
     public BookingMatch createBookingMatch(BookingMatchDTO dto) {
-        // Step 1: Check for time slot overlap
+        // Check if the requested time slot is available for the place.
         boolean isAvailable = dummyMatches.stream()
                 .filter(m -> m.getPlace().getId().equals(dto.placeId()))
                 .noneMatch(existing ->
@@ -35,7 +44,7 @@ public class BookingMatchService {
             throw new IllegalStateException("Time slot is already booked for this place.");
         }
 
-        // Step 2: Fake fetches entities
+        // Fetch related entities from in-memory lists.
         Place place = dummyPlaces.stream()
                 .filter(p -> p.getId().equals(dto.placeId()))
                 .findFirst()
@@ -51,7 +60,7 @@ public class BookingMatchService {
                 .findFirst()
                 .orElseThrow(() -> new EntityNotFoundException("Team not found"));
 
-        // Step 3: Create and store match
+        // Build and store the new match.
         BookingMatch match = BookingMatch.builder()
                 .id((long) (dummyMatches.size() + 1)) // Simulate auto ID
                 .place(place)
@@ -63,15 +72,18 @@ public class BookingMatchService {
                 .build();
 
         dummyMatches.add(match);
+        // bookingMatchRepository.save(match); // Uncomment for real DB
         return match;
     }
 
+    // Cancels a match by setting its status to CANCEL.
     public BookingMatch cancelBooking(Long matchId) {
         BookingMatch match = getById(matchId);
         match.setStatus(MatchStatus.CANCELLED);
         return match;
     }
 
+    // Retrieves a match by its ID.
     public BookingMatch getById(Long id) {
         return dummyMatches.stream()
                 .filter(m -> m.getId().equals(id))
@@ -79,19 +91,36 @@ public class BookingMatchService {
                 .orElseThrow(() -> new EntityNotFoundException("Match not found"));
     }
 
+    // Returns all matches for a user.
     public List<BookingMatch> getByUser(Long userId) {
         return dummyMatches.stream()
                 .filter(m -> m.getUser().getId().equals(userId))
                 .toList();
     }
 
+    // Returns all matches for a team.
     public List<BookingMatch> getByTeam(Long teamId) {
         return dummyMatches.stream()
                 .filter(m -> m.getTeam().getId().equals(teamId))
                 .toList();
     }
 
-    // Optional: Method to preload fake data for testing
+    // Returns all matches for a place.
+    public List<BookingMatch> getByPlace(Long placeId) {
+        return dummyMatches.stream()
+                .filter(m -> m.getPlace().getId().equals(placeId))
+                .toList();
+    }
+
+    // Returns all booking matches in the system.
+    public List<BookingMatch> getAll() {
+//         return bookingMatchRepository.findAll();
+
+        return new ArrayList<>(dummyMatches);
+    }
+
+
+    // Loads test data into the in-memory lists.
     public void seedData(List<User> users, List<Place> places, List<Team> teams) {
         this.dummyUsers = users;
         this.dummyPlaces = places;

--- a/football-places-booking-system/src/main/java/hypercell/final_project/football_places_booking_system/util/DummyDataLoader.java
+++ b/football-places-booking-system/src/main/java/hypercell/final_project/football_places_booking_system/util/DummyDataLoader.java
@@ -1,0 +1,54 @@
+package hypercell.final_project.football_places_booking_system.util;
+
+import hypercell.final_project.football_places_booking_system.model.db.Place;
+import hypercell.final_project.football_places_booking_system.model.db.Team;
+import hypercell.final_project.football_places_booking_system.model.db.User;
+import hypercell.final_project.football_places_booking_system.model.enums.*;
+import hypercell.final_project.football_places_booking_system.service.BookingMatchService;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class DummyDataLoader {
+
+    private final BookingMatchService bookingMatchService;
+
+    @PostConstruct
+    public void initDummyData() {
+        List<User> users = List.of(
+                User.builder()
+                        .id(1L)
+                        .username("Ali")
+                        .email("ali@example.com")
+                        .password("dummy123")
+                        .role(UserRole.USER)
+                        .status(UserStatus.ACTIVE)
+                        .build()
+        );
+
+        List<Place> places = List.of(
+                Place.builder()
+                        .id(1L)
+                        .name("Cairo Pitch")
+                        .location("Cairo")
+                        .placeType(PlaceType.FIVE)
+                        .imageUrl("img.jpg")
+                        .build()
+        );
+
+        List<Team> teams = List.of(
+                Team.builder()
+                        .id(1L)
+                        .name("Falcons")
+                        .description("Top team")
+                        .createdBy(1L)
+                        .build()
+        );
+
+        bookingMatchService.seedData(users, places, teams);
+    }
+}

--- a/football-places-booking-system/src/main/resources/db/changelog/005_create_booking_match_table.yaml
+++ b/football-places-booking-system/src/main/resources/db/changelog/005_create_booking_match_table.yaml
@@ -5,7 +5,7 @@ databaseChangeLog:
       changes:
         - createTable:
             tableName: booking_match
-            remarks: "BookingMatch table represents a scheduled match at a specific place and time. Links to the booking user, place, and team involved in the match."
+            remarks: "BookingMatch table represents a scheduled match at a specific place and time."
             columns:
               - column:
                   name: id


### PR DESCRIPTION
This PR introduces the Booking Match functionality to the application. It allows users to create, view, and cancel bookings for football matches on available places. This version currently uses in-memory dummy data but includes structure ready for integration with the database layer.